### PR TITLE
Chore: Use CDN for base pack

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -13,6 +13,12 @@
      <!-- 下方为百度搜索接入 -->
      <!-- 上方为网页特效 -->
      <title>小肉包按钮</title>
+     <% if (process.env.NODE_ENV === 'production') { %>
+      <script src="https://cdn.jsdelivr.net/npm/vue@3.2.36/dist/vue.global.min.js"></script>
+      <script src="https://cdn.jsdelivr.net/npm/vue-i18n@9.2.0-beta.35/dist/vue-i18n.global.min.js"></script>
+      <script src="https://cdn.jsdelivr.net/npm/element-plus@2.2.2/dist/index.full.min.js"></script>
+      <link href="https://cdn.jsdelivr.net/npm/element-plus@2.2.2/dist/index.min.css" rel="stylesheet">
+    <% } %>
      <!-- Global site tag (gtag.js) - Google Analytics -->
 <!--下方为google统计接入-->
       <script async src="https://www.googletagmanager.com/gtag/js?id=G-XFVLS8NZ17"></script>

--- a/vue.config.js
+++ b/vue.config.js
@@ -75,7 +75,9 @@ module.exports = {
       performance: {
         hints: false
       },
-      plugins: process.env.NODE_ENV === 'production' ? [] : [
+      plugins: process.env.NODE_ENV === 'production' ? [new BundleAnalyzerPlugin({
+        generateStatsFile: false
+      })] : [
         new BundleAnalyzerPlugin({
           generateStatsFile: false
         }),
@@ -87,6 +89,11 @@ module.exports = {
           resolvers: [ElementPlusResolver()]
         })
       ],
+      externals: process.env.NODE_ENV === 'production' ? {
+        vue: 'Vue',
+        'vue-i18n': 'VueI18n',
+        'element-plus': 'ElementPlus'
+      } : {},
       optimization: {
         splitChunks: {
           chunks: 'all',


### PR DESCRIPTION
# OverView

Because of the cloudflare’s network is very slow in domestic(China), I suggest we can use cdn to make base files smaller.

## What has been changed

Use cdn for `ElementPlus`、 `Vue`、 `VueI18n` at env `production`

`js/chunk-libs.js` gzip size:

- before: 407.19 kb

- after: 10.46 kb